### PR TITLE
ci: change name of released zip

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,10 @@ jobs:
         with:
         # Filename for archive
           exclusions: '*.git*'
-          filename: Hyper.zip
+          filename: Hyper.spoon.zip
       - name: Upload Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "Hyper.zip"
+          artifacts: "Hyper.spoon.zip"
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true


### PR DESCRIPTION
I changed the name of the released zip so that, when double-clicked, it extracts to Hyper.spoon which can immediately be installed by double-clicking

Fixes #2